### PR TITLE
[Swagger] bulkDelete API gives an empty response with 200 instead of a msg with the count of records that got deleted

### DIFF
--- a/api/controllers/main.controller.js
+++ b/api/controllers/main.controller.js
@@ -442,7 +442,9 @@ router.delete('/utils/bulkDelete', async (req, res) => {
 			.map((doc) => doc._id);
 		const docsNotRemoved = _.difference(_.uniq(ids), removedIds);
 		if (_.isEmpty(docsNotRemoved)) {
-			return res.status(200).json({});
+			return res.status(200).json({
+				message: `${removedIds.length} record(s) deleted successfully.`,
+			});
 		} else {
 			return res.status(400).json({
 				message: 'Could not delete document with id ' + docsNotRemoved,


### PR DESCRIPTION
Sent out 200 OK response with the count of records deleted for successful bulk deletes